### PR TITLE
docs(flutter): release 2.1.0

### DIFF
--- a/docs/framework/flutter/Flutter SDK.md
+++ b/docs/framework/flutter/Flutter SDK.md
@@ -34,7 +34,7 @@ import TabItem from '@theme/TabItem';
 
 ```c
 dependencies:
-  growingio_autotracker_flutter_plugin: '1.1.3'
+  growingio_autotracker_flutter_plugin: '2.1.0'
 ```
 
 </TabItem>
@@ -43,7 +43,7 @@ dependencies:
 
 ```c
 dependencies:
-  growingio_tracker_flutter_plugin: '1.1.3'
+  growingio_tracker_flutter_plugin: '2.1.0'
 ```
 
 </TabItem>
@@ -60,6 +60,7 @@ dependencies:
   | = v1.0.0 | >= v3.4.7 | >= v3.4.8 |
   | = v1.1.0 | >= v3.5.0 | >= v3.5.0 |
   | = v1.1.3 | >= v3.5.0 | >= v3.5.0 |
+  | = v2.1.0 | >= v3.5.0 | >= v3.5.0 |
 
 </details>
 

--- a/docs/framework/flutter/index.md
+++ b/docs/framework/flutter/index.md
@@ -12,6 +12,7 @@ Flutter SDK 提供了无埋点 SDK 和埋点 SDK 两个版本：
 ## 版本记录
 |    版本    | 说明 |  日期  |
 |:-------:| :----  |  :-------:  |
+| v2.1.0 | - 修复应用从后台回到前台时，补发的 PAGE timestamp 未刷新 | 2024-04-23 |
 | v1.1.3 | - 修复 iOS 在元素位置信息为 NaN 情况下出现圈选界面不刷新<br/>- 修复 UrlScheme 多环境配置 | 2023-10-18 |
 | V1.1.0 | - 原生 SDK 升级至 3.5.0；<br/>- 修复由于 Android SDK 升级导致的 Android Flutter plugin 类的签名不匹配；<br/>- 修复 iOS 从前台到挂起状态下直接杀死 App 异常崩溃捕获。 | 2023-07-26 |
 | V1.0.0 | 这是 Growingio Flutter SDK Library 的第一个正式版，它包含了以下内容：<br/>- 全新的 Flutter 埋点插件，能几乎支持原生的全部功能；<br/>- 通过 Flutter Aspect 支持 SDK 的无埋点功能；<br/>- 支持 Flutter 无埋点页面事件，能够基于 Navigation 路由机制发送页面事件；<br/>- 支持 Flutter 无埋点点击事件，能够在用户点击时发送点击事件；<br/>- 支持 Flutter 圈选，将可交互 Widget 与无埋点事件绑定。 | 2023-04-07 |


### PR DESCRIPTION
修复应用从后台回到前台时，补发的 PAGE timestamp 未刷新